### PR TITLE
Write `TwitterTweetBot::API::HTTP` Spec 🛡️ 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ end
 group :test do
   gem 'faker', '~> 3.2'
   gem 'rspec', '~> 3.12'
+  gem 'webmock', '~> 3.18'
 end

--- a/lib/twitter_tweet_bot/api/access_token.rb
+++ b/lib/twitter_tweet_bot/api/access_token.rb
@@ -52,9 +52,7 @@ module TwitterTweetBot
       end
 
       def headers
-        basic_authorization_header(
-          Base64.strict_encode64("#{client_id}:#{client_secret}")
-        )
+        basic_authorization_header(client_id, client_secret)
       end
 
       private_constant :API_ENDPOTNT,

--- a/lib/twitter_tweet_bot/api/http/headers.rb
+++ b/lib/twitter_tweet_bot/api/http/headers.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'uri'
 require 'net/http'
 
@@ -8,12 +9,23 @@ module TwitterTweetBot
         BASIC_AUTHORIZATION = 'Basic %<credentials>s'.freeze
         BEARER_AUTHORIZATION = 'Bearer %<credentials>s'.freeze
 
-        def basic_authorization_header(credentials)
-          { authorization: format(BASIC_AUTHORIZATION, credentials: credentials) }
+        def basic_authorization_header(user, password)
+          {
+            authorization: format(
+              BASIC_AUTHORIZATION,
+              credentials: authorization_credentials(user, password)
+            )
+          }
         end
 
         def bearer_authorization_header(credentials)
           { authorization: format(BEARER_AUTHORIZATION, credentials: credentials) }
+        end
+
+        private
+
+        def authorization_credentials(user, password)
+          Base64.strict_encode64("#{user}:#{password}")
         end
       end
     end

--- a/lib/twitter_tweet_bot/api/http/post.rb
+++ b/lib/twitter_tweet_bot/api/http/post.rb
@@ -9,8 +9,8 @@ module TwitterTweetBot
       module Post
         include Base
 
-        JSON_CONTENT_TYPE = 'application/json'.freeze
         URLENCODED_CONTENT_TYPE = 'application/x-www-form-urlencoded; charset=UTF-8'.freeze
+        JSON_CONTENT_TYPE = 'application/json'.freeze
 
         def request_post_form(url, body, headers = {})
           request_post(

--- a/lib/twitter_tweet_bot/api/refresh_token.rb
+++ b/lib/twitter_tweet_bot/api/refresh_token.rb
@@ -1,4 +1,3 @@
-require 'base64'
 require 'twitter_tweet_bot/api/http'
 
 module TwitterTweetBot
@@ -43,9 +42,7 @@ module TwitterTweetBot
       end
 
       def headers
-        basic_authorization_header(
-          Base64.strict_encode64("#{client_id}:#{client_secret}")
-        )
+        basic_authorization_header(client_id, client_secret)
       end
 
       private_constant :API_ENDPOTNT,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,4 +108,8 @@ RSpec.configure do |config|
 
   # Specify `require` files before run specs.
   config.requires = Dir[File.join(__dir__, 'support/**/*.rb')]
+
+  # Specify `include` modules before run specs.
+  config.include(CustomMemoizedHelpers)
+  config.include(RequestHelpers)
 end

--- a/spec/support/custom_memoized_helpers.rb
+++ b/spec/support/custom_memoized_helpers.rb
@@ -1,0 +1,5 @@
+module CustomMemoizedHelpers
+  def is_expect_caused
+    expect { subject }
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,19 @@
+require 'webmock/rspec'
+
+module RequestHelpers
+  def a_get(uri)
+    a_request(:get, uri)
+  end
+
+  def a_post(uri)
+    a_request(:post, uri)
+  end
+
+  def stub_get(uri)
+    stub_request(:get, uri)
+  end
+
+  def stub_post(uri)
+    stub_request(:post, uri)
+  end
+end

--- a/spec/twitter_tweet_bot/api/http/base_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/base_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe TwitterTweetBot::API::HTTP::Base do
+  let(:http_klass) do
+    Class.new.tap do |klass|
+      klass.instance_exec(described_class) do |mod|
+        include mod
+      end
+    end
+  end
+
+  describe '#perform_request' do
+    subject(:http) do
+      http_klass.new.perform_request(
+        URI(uri),
+        Net::HTTP::Get.new(URI(uri), { 'X-Dummy' => 'dummy' })
+      )
+    end
+
+    let(:uri) { Faker::Internet.url }
+    let(:body) { { foo: :bar }.to_json }
+
+    before { stub_get(uri).to_return(body: body) }
+
+    it 'executes a request' do
+      expect(http.code).to eq('200')
+      expect(http.body).to eq(body)
+
+      expect(
+        a_get(uri).with(headers: { 'X-Dummy' => 'dummy' })
+      ).to have_been_made.once
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/http/error_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/error_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe TwitterTweetBot::API::HTTP::Error do
+  describe 'RequestFaild' do
+    describe '#message' do
+      subject do
+        described_class::RequestFaild
+          .new(400, body)
+          .message
+      end
+
+      let(:body) { { error: 'invalid_request' }.to_json }
+
+      it 'returns an error message' do
+        is_expected.to eq("400\n#{body}")
+      end
+    end
+  end
+
+  describe '#request_error!' do
+    subject do
+      http_klass
+        .new.request_error!(400, body)
+    end
+
+    let(:http_klass) do
+      Class.new.tap do |klass|
+        klass.instance_exec(described_class) do |mod|
+          include mod
+        end
+      end
+    end
+
+    let(:body) { { error: 'invalid_request' }.to_json }
+
+    it 'raises `RequestFaild`' do
+      is_expect_caused.to(
+        raise_error(described_class::RequestFaild) do |error|
+          expect(error.message).to eq("400\n#{body}")
+        end
+      )
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/http/get_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/get_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe TwitterTweetBot::API::HTTP::Get do
+  let(:http_klass) do
+    Class.new.tap do |klass|
+      klass.instance_exec(described_class) do |mod|
+        include mod
+      end
+    end
+  end
+
+  describe '#request_get' do
+    let(:uri) { Faker::Internet.url }
+    let(:uri_with_query) { "#{uri}?#{URI.encode_www_form(query)}" }
+    let(:query) { { foo: :bar } }
+
+    before do
+      stub_get(uri_with_query)
+        .to_return(body: { piyo: :piyopiyo }.to_json)
+    end
+
+    context 'when headers are given' do
+      subject(:http) do
+        http_klass.new.request_get(
+          uri, query, { 'X-Dummy' => 'dummy' }
+        )
+      end
+
+      it 'executes a request with given headers' do
+        expect(http.code).to eq('200')
+        expect(http.body).to eq({ piyo: :piyopiyo }.to_json)
+
+        expect(
+          a_get(uri_with_query)
+            .with(headers: { 'X-Dummy' => 'dummy' })
+        ).to have_been_made.once
+      end
+    end
+
+    context 'when headers are NOT given' do
+      subject(:http) do
+        http_klass.new.request_get(uri, query)
+      end
+
+      it 'executes a request' do
+        expect(http.code).to eq('200')
+        expect(http.body).to eq({ piyo: :piyopiyo }.to_json)
+
+        expect(a_get(uri_with_query)).to have_been_made.once
+      end
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/http/headers_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/headers_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe TwitterTweetBot::API::HTTP::Headers do
+  let(:http_klass) do
+    Class.new.tap do |klass|
+      klass.instance_exec(described_class) do |mod|
+        include mod
+      end
+    end
+  end
+
+  describe '#basic_authorization_header' do
+    subject do
+      http_klass.new.basic_authorization_header(user, password)
+    end
+
+    let(:user) { Faker::Internet.username }
+    let(:password) { Faker::Internet.password }
+
+    it 'returns a header for basic authorization' do
+      is_expected.to eq(
+        {
+          authorization: \
+            format('Basic %s', Base64.strict_encode64("#{user}:#{password}"))
+        }
+      )
+    end
+  end
+
+  describe '#bearer_authorization_header' do
+    subject do
+      http_klass.new.bearer_authorization_header(credentials)
+    end
+
+    let(:credentials) { Faker::Alphanumeric.alpha(number: 5) }
+
+    it 'returns a header for bearer authorization' do
+      is_expected.to eq({ authorization: "Bearer #{credentials}" })
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/http/post_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/post_spec.rb
@@ -1,0 +1,117 @@
+RSpec.describe TwitterTweetBot::API::HTTP::Post do
+  let(:http_klass) do
+    Class.new.tap do |klass|
+      klass.instance_exec(described_class) do |mod|
+        include mod
+      end
+    end
+  end
+
+  describe '#request_post_form' do
+    let(:uri) { Faker::Internet.url }
+    let(:body) { { foo: :bar } }
+
+    before do
+      stub_post(uri)
+        .to_return(body: { piyo: :piyopiyo }.to_json)
+    end
+
+    context 'when headers are given' do
+      subject(:http) do
+        http_klass.new.request_post_form(
+          uri, body, { 'X-Dummy' => 'dummy' }
+        )
+      end
+
+      it 'executes a request with given headers' do
+        expect(http.code).to eq('200')
+        expect(http.body).to eq({ piyo: :piyopiyo }.to_json)
+
+        expect(
+          a_post(uri)
+            .with(
+              body: URI.encode_www_form(body),
+              headers: {
+                'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8',
+                'X-Dummy' => 'dummy'
+              }
+            )
+        ).to have_been_made.once
+      end
+    end
+
+    context 'when headers are NOT given' do
+      subject(:http) do
+        http_klass.new.request_post_form(uri, body)
+      end
+
+      it 'executes a request' do
+        expect(http.code).to eq('200')
+        expect(http.body).to eq({ piyo: :piyopiyo }.to_json)
+
+        expect(
+          a_post(uri)
+            .with(
+              body: URI.encode_www_form(body),
+              headers: {
+                'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8'
+              }
+            )
+        ).to have_been_made.once
+      end
+    end
+  end
+
+  describe '#request_post_json' do
+    let(:uri) { Faker::Internet.url }
+    let(:body) { { foo: :bar } }
+
+    before do
+      stub_post(uri)
+        .to_return(body: { piyo: :piyopiyo }.to_json)
+    end
+
+    context 'when headers are given' do
+      subject(:http) do
+        http_klass.new.request_post_json(
+          uri, body, { 'X-Dummy' => 'dummy' }
+        )
+      end
+
+      it 'executes a request with given headers' do
+        expect(http.code).to eq('200')
+        expect(http.body).to eq({ piyo: :piyopiyo }.to_json)
+
+        expect(
+          a_post(uri)
+            .with(
+              body: body.to_json,
+              headers: {
+                'Content-Type' => 'application/json',
+                'X-Dummy' => 'dummy'
+              }
+            )
+        ).to have_been_made.once
+      end
+    end
+
+    context 'when headers are NOT given' do
+      subject(:http) do
+        http_klass.new.request_post_json(uri, body)
+      end
+
+      it 'executes a request' do
+        expect(http.code).to eq('200')
+        expect(http.body).to eq({ piyo: :piyopiyo }.to_json)
+
+        expect(
+          a_post(uri)
+            .with(
+              body: body.to_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
+        ).to have_been_made.once
+      end
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/http_spec.rb
+++ b/spec/twitter_tweet_bot/api/http_spec.rb
@@ -1,0 +1,123 @@
+RSpec.describe TwitterTweetBot::API::HTTP do
+  let(:http_klass) do
+    Class.new.tap do |klass|
+      klass.instance_exec(described_class) do |mod|
+        include mod
+      end
+    end
+  end
+
+  describe '#request' do
+    let(:uri) { Faker::Internet.url }
+    let(:body) { { foo: :bar } }
+
+    context 'when GET request' do
+      subject do
+        http_klass.new.request(
+          :get, uri, body, { 'X-Dummy' => 'dummy' }
+        )
+      end
+
+      let(:uri_with_query) { "#{uri}?#{URI.encode_www_form(body)}" }
+
+      before do
+        stub_get(uri_with_query)
+          .to_return(body: { piyo: :piyopiyo }.to_json)
+      end
+
+      it 'executes a GET request' do
+        is_expected.to eq({ piyo: :piyopiyo }.to_json)
+
+        expect(
+          a_get(uri_with_query)
+            .with(headers: { 'X-Dummy' => 'dummy' })
+        ).to have_been_made.once
+      end
+    end
+
+    context 'when POST (Form) request' do
+      subject do
+        http_klass.new.request(
+          :post_form, uri, body, { 'X-Dummy' => 'dummy' }
+        )
+      end
+
+      before do
+        stub_post(uri)
+          .to_return(body: { piyo: :piyopiyo }.to_json)
+      end
+
+      it 'executes a POST (Form) request' do
+        is_expected.to eq({ piyo: :piyopiyo }.to_json)
+
+        expect(
+          a_post(uri)
+            .with(
+              body: URI.encode_www_form(body),
+              headers: {
+                'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8',
+                'X-Dummy' => 'dummy'
+              }
+            )
+        ).to have_been_made.once
+      end
+    end
+
+    context 'when POST (JSON) request' do
+      subject do
+        http_klass.new.request(
+          :post_json, uri, body, { 'X-Dummy' => 'dummy' }
+        )
+      end
+
+      before do
+        stub_post(uri)
+          .to_return(body: { piyo: :piyopiyo }.to_json)
+      end
+
+      it 'executes a POST (JSON) request' do
+        is_expected.to eq({ piyo: :piyopiyo }.to_json)
+
+        expect(
+          a_post(uri)
+            .with(
+              body: body.to_json,
+              headers: {
+                'Content-Type' => 'application/json',
+                'X-Dummy' => 'dummy'
+              }
+            )
+        ).to have_been_made.once
+      end
+    end
+
+    context 'when request failed' do
+      subject do
+        http_klass.new.request(
+          :get, uri, body, { 'X-Dummy' => 'dummy' }
+        )
+      end
+
+      let(:uri_with_query) { "#{uri}?#{URI.encode_www_form(body)}" }
+      let(:response_json) { { error: 'invalid_request' }.to_json }
+
+      before do
+        stub_get(uri_with_query)
+          .to_return(status: 400, body: response_json)
+      end
+
+      it 'raises `Error::RequestFaild`' do
+        is_expect_caused.to(
+          raise_error(described_class::Error::RequestFaild) do |error|
+            expect(error.message).to eq("400\n#{response_json}")
+          end
+        )
+
+        expect(
+          a_get(uri_with_query)
+            .with(headers: { 'X-Dummy' => 'dummy' })
+        ).to have_been_made.once
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Write unit tests for `TwitterTweetBot::API::HTTP`.

- `spec/twitter_tweet_bot/api/http_spec.rb`
- `spec/twitter_tweet_bot/api/http/*.rb`

### And ...

Change `TwitterTweetBot::API::HTTP::Headers#basic_authorization_header` I / F.

```
# Before
TwitterTweetBot::API::HTTP::Headers#basic_authorization_header('user:pass')

# After
TwitterTweetBot::API::HTTP::Headers#basic_authorization_header('user', 'pass')
```