### PR TITLE
Write `TwitterTweetBot::API` Spec 🛡️ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ end
 #### Step2. Issue an authorization url
 
 ```rb
-authorization = TwitterTweetBot.authorization
+authorization = TwitterTweetBot.authorize
 # =>
 #  #<TwitterTweetBot::Entity::Authorization
 #   @code_verifier="*****",
@@ -139,7 +139,7 @@ end
 
 ```rb
 # `code_verifier` and `state` will be cached.
-TwitterTweetBot.authorization
+TwitterTweetBot.authorize
 ```
 
 #### Step3. Fetch an access token

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ authorization = TwitterTweetBot.authorization
 #   @url="https://twitter.com/i/oauth2/authorize?response_type=code&redirect_uri=<YOUR_REDIRECT_URI>&client_id=<YOUR_CLIENT_ID>&scope=<SCOPES>&code_challenge=*****&code_challenge_method=S256&state=***">
 ```
 
-#### Step3. Rerirect (or Go) to `authorization.url`
+#### Step3. Redirect (or Go) to `authorization.url`
 
 And smash `"Authorize app"`.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ TwitterTweetBot.post_tweet(token.access_token, 'Yeah!')
 #   @text="Yeah!">
 ```
 
-#### Ex. Restore an access token (required `'offline.access'` in scopes)
+#### Ex. Refresh an access token (required `'offline.access'` in scopes)
 
 ```rb
 TwitterTweetBot.refresh_token(token.refresh_token)

--- a/lib/twitter_tweet_bot.rb
+++ b/lib/twitter_tweet_bot.rb
@@ -19,7 +19,7 @@ module TwitterTweetBot
       Client.new(config || default_config!)
     end
 
-    delegate :authorization,
+    delegate :authorize,
              :fetch_token,
              :refresh_token,
              :post_tweet,

--- a/lib/twitter_tweet_bot/api/authorization.rb
+++ b/lib/twitter_tweet_bot/api/authorization.rb
@@ -11,7 +11,7 @@ module TwitterTweetBot
       AUTH_URL = 'https://twitter.com/i/oauth2/authorize'.freeze
       RESPONSE_TYPE = 'code'.freeze
 
-      def self.authorization(
+      def self.authorize(
         client_id:,
         redirect_uri:,
         scopes:,
@@ -21,7 +21,7 @@ module TwitterTweetBot
         **
       )
         new(client_id, redirect_uri, scopes)
-          .authorization(code_verifier, code_challenge_method, state)
+          .authorize(code_verifier, code_challenge_method, state)
       end
 
       def initialize(client_id, redirect_uri, scopes)
@@ -30,7 +30,7 @@ module TwitterTweetBot
         @scopes = scopes
       end
 
-      def authorization(code_verifier, code_challenge_method, state)
+      def authorize(code_verifier, code_challenge_method, state)
         secure_code = Authorization::SecureCode.new(
           code_verifier: code_verifier,
           code_challenge_method: code_challenge_method,

--- a/lib/twitter_tweet_bot/api/authorization/secure_code.rb
+++ b/lib/twitter_tweet_bot/api/authorization/secure_code.rb
@@ -20,15 +20,14 @@ module TwitterTweetBot
           end
 
           def code_challenge(verifier, challenge_method = DEFAULT_CHALLENGE_METHOD)
-            hashed_verifier = \
-              case challenge_method
-              when 'S256'
-                digest_by_sha256(verifier)
-              else # 'plain'
-                verifier
-              end
-
-            encode(Base64.urlsafe_encode64(hashed_verifier, padding: false))
+            case challenge_method
+            when 'S256'
+              encode(
+                Base64.urlsafe_encode64(digest_by_sha256(verifier), padding: false)
+              )
+            else # 'plain'
+              encode(verifier)
+            end
           end
 
           private

--- a/lib/twitter_tweet_bot/cache/client_ext.rb
+++ b/lib/twitter_tweet_bot/cache/client_ext.rb
@@ -5,7 +5,7 @@ module TwitterTweetBot
     module ClientExt
       include Caching
 
-      def authorization(*)
+      def authorize(*)
         with_cache { super }
       end
 

--- a/lib/twitter_tweet_bot/client/api.rb
+++ b/lib/twitter_tweet_bot/client/api.rb
@@ -3,8 +3,8 @@ require 'twitter_tweet_bot/api'
 module TwitterTweetBot
   class Client
     module API
-      def authorization(code_verifier = nil, code_challenge_method = nil, state = nil)
-        TwitterTweetBot::API::Authorization.authorization(
+      def authorize(code_verifier = nil, code_challenge_method = nil, state = nil)
+        TwitterTweetBot::API::Authorization.authorize(
           **params_with_config(
             code_verifier: code_verifier,
             code_challenge_method: code_challenge_method,

--- a/lib/twitter_tweet_bot/client/entity.rb
+++ b/lib/twitter_tweet_bot/client/entity.rb
@@ -4,7 +4,7 @@ require 'twitter_tweet_bot/entity'
 module TwitterTweetBot
   class Client
     module Entity
-      def authorization(*)
+      def authorize(*)
         with_entity(TwitterTweetBot::Entity::Authorization) { super }
       end
 

--- a/spec/twitter_tweet_bot/api/access_token_spec.rb
+++ b/spec/twitter_tweet_bot/api/access_token_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe TwitterTweetBot::API::AccessToken do
+  describe '::fetch' do
+    subject { described_class.fetch(**params) }
+
+    let(:params) do
+      {
+        client_id: Faker::Alphanumeric.alpha(number: 5),
+        client_secret: Faker::Alphanumeric.alpha(number: 5),
+        redirect_uri: Faker::Internet.url,
+        code: Faker::Alphanumeric.alpha(number: 5),
+        code_verifier: Faker::Alphanumeric.alpha(number: 5)
+      }
+    end
+    let(:response_json) { { access_token: '*' * 5 }.to_json }
+
+    before do
+      stub_post('https://api.twitter.com/2/oauth2/token')
+        .to_return(body: response_json)
+    end
+
+    it 'fetches an access_token' do
+      is_expected.to eq(response_json)
+
+      expect(
+        a_post('https://api.twitter.com/2/oauth2/token')
+          .with(
+            body: URI.encode_www_form(
+              {
+                grant_type: 'authorization_code',
+                code: params[:code],
+                code_verifier: params[:code_verifier],
+                redirect_uri: params[:redirect_uri]
+              }
+            ),
+            headers: {
+              'Authorization' => format(
+                'Basic %s',
+                Base64.strict_encode64("#{params[:client_id]}:#{params[:client_secret]}")
+              ),
+              'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8'
+            }
+          )
+      ).to have_been_made.once
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/authorization/secure_code_spec.rb
+++ b/spec/twitter_tweet_bot/api/authorization/secure_code_spec.rb
@@ -93,11 +93,9 @@ RSpec.describe TwitterTweetBot::API::Authorization::SecureCode do
 
       let(:code_verifier) { Faker::Alphanumeric.alpha(number: 5) }
 
-      it 'returns an encoded string by base64' do
+      it 'returns a same string as given' do
         expect(code_challenge).to be_a(String)
-        expect(code_challenge).to eq(
-          Base64.urlsafe_encode64(code_verifier, padding: false)
-        )
+        expect(code_challenge).to eq(code_verifier)
         expect(code_challenge.encoding).to eq(Encoding::UTF_8)
       end
     end

--- a/spec/twitter_tweet_bot/api/authorization_spec.rb
+++ b/spec/twitter_tweet_bot/api/authorization_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe TwitterTweetBot::API::Authorization do
+  describe '::authorize' do
+    subject(:authorization) do
+      described_class.authorize(**params)
+    end
+
+    context 'when authorization params are given' do
+      let(:params) do
+        {
+          client_id: Faker::Alphanumeric.alpha(number: 5),
+          redirect_uri: Faker::Internet.url,
+          scopes: %w[tweet.read tweet.write users.read offline.access],
+          code_verifier: Faker::Alphanumeric.alpha(number: 5),
+          code_challenge_method: 'S256',
+          state: Faker::Alphanumeric.alpha(number: 5)
+        }
+      end
+
+      before do
+        allow(TwitterTweetBot::API::Authorization::SecureCode).to(
+          receive(:code_challenge).and_return('*' * 5)
+        )
+      end
+
+      it 'builds authorization information as Hash' do
+        expect(authorization).to be_a(Hash)
+        expect(authorization[:url]).to eq(
+          URI('https://twitter.com/i/oauth2/authorize').tap do |uri|
+            uri.query = URI.encode_www_form(
+              {
+                response_type: 'code',
+                redirect_uri: params[:redirect_uri],
+                client_id: params[:client_id],
+                scope: params[:scopes].join(' '),
+                code_challenge: '*' * 5,
+                code_challenge_method: params[:code_challenge_method],
+                state: params[:state]
+              }
+            )
+          end.to_s
+        )
+        expect(authorization[:code_verifier]).to eq(params[:code_verifier])
+        expect(authorization[:state]).to eq(params[:state])
+
+        expect(TwitterTweetBot::API::Authorization::SecureCode).to(
+          have_received(:code_challenge)
+            .with(params[:code_verifier], params[:code_challenge_method])
+            .once
+        )
+      end
+    end
+
+    context 'when ONLY specific authorization params are given' do
+      let(:params) do
+        {
+          client_id: Faker::Alphanumeric.alpha(number: 5),
+          redirect_uri: Faker::Internet.url,
+          scopes: %w[tweet.read tweet.write users.read offline.access],
+          code_verifier: nil,
+          code_challenge_method: nil,
+          state: nil
+        }
+      end
+
+      before do
+        allow(TwitterTweetBot::API::Authorization::SecureCode).to(
+          receive(:code_verifier).and_return('*' * 3)
+        )
+
+        allow(TwitterTweetBot::API::Authorization::SecureCode).to(
+          receive(:state).and_return('*' * 4)
+        )
+
+        allow(TwitterTweetBot::API::Authorization::SecureCode).to(
+          receive(:code_challenge).and_return('*' * 5)
+        )
+      end
+
+      it 'return authorization information as Hash' do
+        expect(authorization).to be_a(Hash)
+        expect(authorization[:url]).to eq(
+          URI('https://twitter.com/i/oauth2/authorize').tap do |uri|
+            uri.query = URI.encode_www_form(
+              {
+                response_type: 'code',
+                redirect_uri: params[:redirect_uri],
+                client_id: params[:client_id],
+                scope: params[:scopes].join(' '),
+                code_challenge: '*' * 5,
+                code_challenge_method: 'S256',
+                state: '*' * 4
+              }
+            )
+          end.to_s
+        )
+        expect(authorization[:code_verifier]).to eq('*' * 3)
+        expect(authorization[:state]).to eq('*' * 4)
+
+        expect(TwitterTweetBot::API::Authorization::SecureCode).to(
+          have_received(:code_verifier)
+            .with(no_args).once
+        )
+        expect(TwitterTweetBot::API::Authorization::SecureCode).to(
+          have_received(:state)
+            .with(no_args).once
+        )
+        expect(TwitterTweetBot::API::Authorization::SecureCode).to(
+          have_received(:code_challenge)
+            .with('*' * 3, 'S256').once
+        )
+      end
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/refresh_token_spec.rb
+++ b/spec/twitter_tweet_bot/api/refresh_token_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe TwitterTweetBot::API::RefreshToken do
+  describe '::fetch' do
+    subject { described_class.fetch(**params) }
+
+    let(:params) do
+      {
+        client_id: Faker::Alphanumeric.alpha(number: 5),
+        client_secret: Faker::Alphanumeric.alpha(number: 5),
+        refresh_token: Faker::Alphanumeric.alpha(number: 5)
+      }
+    end
+    let(:response_json) { { access_token: '*' * 5 }.to_json }
+
+    before do
+      stub_post('https://api.twitter.com/2/oauth2/token')
+        .to_return(body: response_json)
+    end
+
+    it 'refresh an access_token' do
+      is_expected.to eq(response_json)
+
+      expect(
+        a_post('https://api.twitter.com/2/oauth2/token')
+          .with(
+            body: URI.encode_www_form(
+              {
+                grant_type: 'refresh_token',
+                refresh_token: params[:refresh_token],
+                client_id: params[:client_id]
+              }
+            ),
+            headers: {
+              'Authorization' => format(
+                'Basic %s',
+                Base64.strict_encode64("#{params[:client_id]}:#{params[:client_secret]}")
+              ),
+              'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8'
+            }
+          )
+      ).to have_been_made.once
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/tweet_spec.rb
+++ b/spec/twitter_tweet_bot/api/tweet_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe TwitterTweetBot::API::Tweet do
+  describe '::post' do
+    subject { described_class.post(**params) }
+
+    let(:params) do
+      {
+        access_token: Faker::Alphanumeric.alpha(number: 5),
+        text: Faker::Lorem.word
+      }
+    end
+    let(:response_json) { { data: params.slice(:text) }.to_json }
+
+    before do
+      stub_post('https://api.twitter.com/2/tweets')
+        .to_return(body: response_json)
+    end
+
+    it 'posts a tweet' do
+      is_expected.to eq(response_json)
+
+      expect(
+        a_post('https://api.twitter.com/2/tweets')
+          .with(
+            body: params.slice(:text).to_json,
+            headers: {
+              'Authorization' => "Bearer #{params[:access_token]}",
+              'Content-Type' => 'application/json'
+            }
+          )
+      ).to have_been_made.once
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/users_me_spec.rb
+++ b/spec/twitter_tweet_bot/api/users_me_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe TwitterTweetBot::API::UsersMe do
+  describe '::fetch' do
+    subject { described_class.fetch(**params) }
+
+    let(:params) do
+      {
+        access_token: Faker::Alphanumeric.alpha(number: 5),
+        fields: {}
+      }
+    end
+    let(:query) { URI.encode_www_form(params.slice(:fields)) }
+    let(:response_json) { { data: { name: Faker::Internet.username } }.to_json }
+
+    before do
+      stub_get('https://api.twitter.com/2/users/me')
+        .to_return(body: response_json)
+    end
+
+    it 'get current user\'s information' do
+      is_expected.to eq(response_json)
+
+      expect(
+        a_get('https://api.twitter.com/2/users/me')
+          .with(
+            headers: {
+              'Authorization' => "Bearer #{params[:access_token]}"
+            }
+          )
+      ).to have_been_made.once
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Write unit tests for `TwitterTweetBot::API`.

- `spec/twitter_tweet_bot/api/*.rb`

### And ...

Rename `TwitterTweetBot.authorization` -> `TwitterTweetBot.authorize`

```rb
# Before
TwitterTweetBot.authorization

# After
TwitterTweetBot.authorize
```

Does NOT encode `code_challenge` by base64, even if `'plain'` .

```rb
# Before
> TwitterTweetBot::API::Authorization::SecureCode.code_challenge('abcde', code_challenge_method: 'plain')
=> "YWJjZGU"

# After
> TwitterTweetBot::API::Authorization::SecureCode.code_challenge('abcde', code_challenge_method: 'plain')
=> "abcde"
```