### PR TITLE
Enhance support for UsersMe API 🦾 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ require: rubocop-rspec
 AllCops:
   NewCops: enable
 
+RSpec/NestedGroups:
+  Max: 4
+
 # Since using `aggregate_failures` metadata.
 RSpec/MultipleExpectations:
   Enabled: false

--- a/lib/twitter_tweet_bot/api/users_me.rb
+++ b/lib/twitter_tweet_bot/api/users_me.rb
@@ -1,4 +1,5 @@
 require 'twitter_tweet_bot/api/http'
+require 'twitter_tweet_bot/api/users_me/params'
 
 module TwitterTweetBot
   module API
@@ -9,19 +10,23 @@ module TwitterTweetBot
 
       API_ENDPOTNT = 'https://api.twitter.com/2/users/me'.freeze
 
-      def self.fetch(access_token:, fields:, **)
-        new(access_token).fetch(fields)
+      # @param [String] access_token
+      # @param [Hash] params
+      # @option params [String|Array] :tweet_fields
+      # @option params [String|Array] :user_fields
+      def self.fetch(access_token:, params:, **)
+        new(access_token).fetch(params)
       end
 
       def initialize(access_token)
         @access_token = access_token
       end
 
-      def fetch(fields)
+      def fetch(params)
         request(
           :get,
           API_ENDPOTNT,
-          fields,
+          Params.build(params),
           bearer_authorization_header(access_token)
         )
       end

--- a/lib/twitter_tweet_bot/api/users_me/params.rb
+++ b/lib/twitter_tweet_bot/api/users_me/params.rb
@@ -1,0 +1,40 @@
+module TwitterTweetBot
+  module API
+    class UsersMe
+      module Params
+        FIELDS_KEYS = {
+          expansions: 'expansions',
+          tweet_fields: 'tweet.fields',
+          user_fields: 'user.fields'
+        }.freeze
+        FIELDS_DELIMITER = ','.freeze
+
+        # @param [Hash] params
+        # @option params [String] :expansions
+        # @option params [String|Array] :tweet_fields
+        # @option params [String|Array] :user_fields
+        class << self
+          def build(params)
+            slice(params)
+              .transform_keys { |key| FIELDS_KEYS[key] }
+              .transform_values do |value|
+                next value unless value.is_a?(Array)
+
+                value.join(FIELDS_DELIMITER)
+              end
+          end
+
+          private
+
+          def slice(params)
+            params.slice(*FIELDS_KEYS.keys)
+          end
+        end
+
+        private_constant :FIELDS_KEYS, :FIELDS_DELIMITER
+      end
+
+      private_constant :Params
+    end
+  end
+end

--- a/lib/twitter_tweet_bot/client/api.rb
+++ b/lib/twitter_tweet_bot/client/api.rb
@@ -34,9 +34,9 @@ module TwitterTweetBot
         )
       end
 
-      def users_me(access_token, fields = {})
+      def users_me(access_token, params = {})
         TwitterTweetBot::API::UsersMe.fetch(
-          **params_with_config(access_token: access_token, fields: fields)
+          **params_with_config(access_token: access_token, params: params)
         )
       end
 

--- a/lib/twitter_tweet_bot/entity/base.rb
+++ b/lib/twitter_tweet_bot/entity/base.rb
@@ -7,28 +7,28 @@ module TwitterTweetBot
       extend ActiveSupport::Concern
 
       class_methods do
+        # @param [Array] fields
         def act_as_entity(*fields)
           class_attribute :fields,
                           instance_writer: false,
                           default: fields
 
-          attr_reader(*fields)
+          attr_reader :row
+
+          fields.each do |field|
+            define_method(field) { target_fields[field] }
+          end
+
+          # @param [Hash] hash
+          define_method(:initialize) { |hash| @row = Hash(hash) }
+
+          define_method(:target_fields) { row }
+          private :target_fields
         end
 
-        def build(json)
-          new(json)
-        end
-      end
-
-      def initialize(json)
-        initialize_fields!(Hash(json))
-      end
-
-      private
-
-      def initialize_fields!(hash)
-        fields.each do |field|
-          instance_variable_set(:"@#{field}", hash[field])
+        # @param [Hash] hash
+        def build(hash)
+          new(hash)
         end
       end
     end

--- a/lib/twitter_tweet_bot/entity/tweet.rb
+++ b/lib/twitter_tweet_bot/entity/tweet.rb
@@ -11,8 +11,10 @@ module TwitterTweetBot
         :edit_history_tweet_ids
       )
 
-      def self.build(json)
-        super(Hash(json)[:data])
+      private
+
+      def target_fields
+        Hash(row[:data])
       end
     end
   end

--- a/lib/twitter_tweet_bot/entity/user.rb
+++ b/lib/twitter_tweet_bot/entity/user.rb
@@ -11,8 +11,10 @@ module TwitterTweetBot
         :username
       )
 
-      def self.build(json)
-        super(Hash(json)[:data])
+      private
+
+      def target_fields
+        Hash(row[:data])
       end
     end
   end

--- a/spec/support/twitter_tweet_bot/entity/base_examples.rb
+++ b/spec/support/twitter_tweet_bot/entity/base_examples.rb
@@ -16,12 +16,12 @@ module Spec
                 expect(entity).to be_a(described_class)
                 expect(
                   described_class
-                ).to have_received(:new).with(data).once
+                ).to have_received(:new).with(body).once
               end
             end
 
             describe '#initialize' do
-              subject { described_class.new(data) }
+              subject { described_class.new(body) }
 
               shared_examples 'initialize an entity' do
                 it 'initialize an entity' do
@@ -31,16 +31,24 @@ module Spec
 
               include_examples 'initialize an entity'
 
-              context 'when data is nil' do
-                let(:data) { nil }
+              context 'when body is nil' do
+                let(:body) { nil }
 
                 include_examples 'initialize an entity'
               end
             end
 
+            describe '#row' do
+              subject { described_class.new(body).row }
+
+              it 'returns a body' do
+                is_expected.to be(body)
+              end
+            end
+
             fields.each do |field|
               describe "##{field}" do
-                subject { described_class.new(data).public_send(field) }
+                subject { described_class.new(body).public_send(field) }
 
                 it "returns an attribute (##{field})" do
                   is_expected.to eq(data[field])

--- a/spec/twitter_tweet_bot/api/access_token_spec.rb
+++ b/spec/twitter_tweet_bot/api/access_token_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe TwitterTweetBot::API::AccessToken do
         code_verifier: Faker::Alphanumeric.alpha(number: 5)
       }
     end
-    let(:response_json) { { access_token: '*' * 5 }.to_json }
+    let(:response_body) { { access_token: '*' * 5 } }
 
     before do
       stub_post('https://api.twitter.com/2/oauth2/token')
-        .to_return(body: response_json)
+        .to_return_json(body: response_body)
     end
 
     it 'fetches an access_token' do
-      is_expected.to eq(response_json)
+      is_expected.to eq(response_body.to_json)
 
       expect(
         a_post('https://api.twitter.com/2/oauth2/token')

--- a/spec/twitter_tweet_bot/api/access_token_spec.rb
+++ b/spec/twitter_tweet_bot/api/access_token_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TwitterTweetBot::API::AccessToken do
 
     before do
       stub_post('https://api.twitter.com/2/oauth2/token')
-        .to_return_json(body: response_body)
+        .and_return_json(body: response_body)
     end
 
     it 'fetches an access_token' do

--- a/spec/twitter_tweet_bot/api/http/base_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/base_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe TwitterTweetBot::API::HTTP::Base do
     end
 
     let(:uri) { Faker::Internet.url }
-    let(:body) { { foo: :bar }.to_json }
+    let(:response_body) { { foo: :bar } }
 
-    before { stub_get(uri).to_return(body: body) }
+    before { stub_get(uri).to_return_json(body: response_body) }
 
     it 'executes a request' do
       expect(http.code).to eq('200')
-      expect(http.body).to eq(body)
+      expect(http.body).to eq(response_body.to_json)
 
       expect(
         a_get(uri).with(headers: { 'X-Dummy' => 'dummy' })

--- a/spec/twitter_tweet_bot/api/http/base_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/base_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TwitterTweetBot::API::HTTP::Base do
     let(:uri) { Faker::Internet.url }
     let(:response_body) { { foo: :bar } }
 
-    before { stub_get(uri).to_return_json(body: response_body) }
+    before { stub_get(uri).and_return_json(body: response_body) }
 
     it 'executes a request' do
       expect(http.code).to eq('200')

--- a/spec/twitter_tweet_bot/api/http/get_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/get_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TwitterTweetBot::API::HTTP::Get do
 
     before do
       stub_get(uri_with_query)
-        .to_return_json(body: { piyo: :piyopiyo })
+        .and_return_json(body: { piyo: :piyopiyo })
     end
 
     context 'when headers are given' do

--- a/spec/twitter_tweet_bot/api/http/get_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/get_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TwitterTweetBot::API::HTTP::Get do
 
     before do
       stub_get(uri_with_query)
-        .to_return(body: { piyo: :piyopiyo }.to_json)
+        .to_return_json(body: { piyo: :piyopiyo })
     end
 
     context 'when headers are given' do

--- a/spec/twitter_tweet_bot/api/http/post_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/post_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TwitterTweetBot::API::HTTP::Post do
 
     before do
       stub_post(uri)
-        .to_return_json(body: { piyo: :piyopiyo })
+        .and_return_json(body: { piyo: :piyopiyo })
     end
 
     context 'when headers are given' do
@@ -68,7 +68,7 @@ RSpec.describe TwitterTweetBot::API::HTTP::Post do
 
     before do
       stub_post(uri)
-        .to_return_json(body: { piyo: :piyopiyo })
+        .and_return_json(body: { piyo: :piyopiyo })
     end
 
     context 'when headers are given' do

--- a/spec/twitter_tweet_bot/api/http/post_spec.rb
+++ b/spec/twitter_tweet_bot/api/http/post_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TwitterTweetBot::API::HTTP::Post do
 
     before do
       stub_post(uri)
-        .to_return(body: { piyo: :piyopiyo }.to_json)
+        .to_return_json(body: { piyo: :piyopiyo })
     end
 
     context 'when headers are given' do
@@ -68,7 +68,7 @@ RSpec.describe TwitterTweetBot::API::HTTP::Post do
 
     before do
       stub_post(uri)
-        .to_return(body: { piyo: :piyopiyo }.to_json)
+        .to_return_json(body: { piyo: :piyopiyo })
     end
 
     context 'when headers are given' do

--- a/spec/twitter_tweet_bot/api/http_spec.rb
+++ b/spec/twitter_tweet_bot/api/http_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe TwitterTweetBot::API::HTTP do
 
       before do
         stub_get(uri_with_query)
-          .to_return_json(body: { piyo: :piyopiyo })
+          .and_return_json(body: { piyo: :piyopiyo })
       end
 
       it 'executes a GET request' do
@@ -44,7 +44,7 @@ RSpec.describe TwitterTweetBot::API::HTTP do
 
       before do
         stub_post(uri)
-          .to_return_json(body: { piyo: :piyopiyo })
+          .and_return_json(body: { piyo: :piyopiyo })
       end
 
       it 'executes a POST (Form) request' do
@@ -72,7 +72,7 @@ RSpec.describe TwitterTweetBot::API::HTTP do
 
       before do
         stub_post(uri)
-          .to_return_json(body: { piyo: :piyopiyo })
+          .and_return_json(body: { piyo: :piyopiyo })
       end
 
       it 'executes a POST (JSON) request' do
@@ -103,7 +103,7 @@ RSpec.describe TwitterTweetBot::API::HTTP do
 
       before do
         stub_get(uri_with_query)
-          .to_return_json(status: 400, body: response_body)
+          .and_return_json(status: 400, body: response_body)
       end
 
       it 'raises `Error::RequestFaild`' do

--- a/spec/twitter_tweet_bot/api/http_spec.rb
+++ b/spec/twitter_tweet_bot/api/http_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe TwitterTweetBot::API::HTTP do
 
       before do
         stub_get(uri_with_query)
-          .to_return(body: { piyo: :piyopiyo }.to_json)
+          .to_return_json(body: { piyo: :piyopiyo })
       end
 
       it 'executes a GET request' do
@@ -44,7 +44,7 @@ RSpec.describe TwitterTweetBot::API::HTTP do
 
       before do
         stub_post(uri)
-          .to_return(body: { piyo: :piyopiyo }.to_json)
+          .to_return_json(body: { piyo: :piyopiyo })
       end
 
       it 'executes a POST (Form) request' do
@@ -72,7 +72,7 @@ RSpec.describe TwitterTweetBot::API::HTTP do
 
       before do
         stub_post(uri)
-          .to_return(body: { piyo: :piyopiyo }.to_json)
+          .to_return_json(body: { piyo: :piyopiyo })
       end
 
       it 'executes a POST (JSON) request' do
@@ -99,17 +99,17 @@ RSpec.describe TwitterTweetBot::API::HTTP do
       end
 
       let(:uri_with_query) { "#{uri}?#{URI.encode_www_form(body)}" }
-      let(:response_json) { { error: 'invalid_request' }.to_json }
+      let(:response_body) { { error: 'invalid_request' } }
 
       before do
         stub_get(uri_with_query)
-          .to_return(status: 400, body: response_json)
+          .to_return_json(status: 400, body: response_body)
       end
 
       it 'raises `Error::RequestFaild`' do
         is_expect_caused.to(
           raise_error(described_class::Error::RequestFaild) do |error|
-            expect(error.message).to eq("400\n#{response_json}")
+            expect(error.message).to eq("400\n#{response_body.to_json}")
           end
         )
 

--- a/spec/twitter_tweet_bot/api/refresh_token_spec.rb
+++ b/spec/twitter_tweet_bot/api/refresh_token_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe TwitterTweetBot::API::RefreshToken do
         refresh_token: Faker::Alphanumeric.alpha(number: 5)
       }
     end
-    let(:response_json) { { access_token: '*' * 5 }.to_json }
+    let(:response_body) { { access_token: '*' * 5 } }
 
     before do
       stub_post('https://api.twitter.com/2/oauth2/token')
-        .to_return(body: response_json)
+        .to_return_json(body: response_body)
     end
 
     it 'refresh an access_token' do
-      is_expected.to eq(response_json)
+      is_expected.to eq(response_body.to_json)
 
       expect(
         a_post('https://api.twitter.com/2/oauth2/token')

--- a/spec/twitter_tweet_bot/api/refresh_token_spec.rb
+++ b/spec/twitter_tweet_bot/api/refresh_token_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TwitterTweetBot::API::RefreshToken do
 
     before do
       stub_post('https://api.twitter.com/2/oauth2/token')
-        .to_return_json(body: response_body)
+        .and_return_json(body: response_body)
     end
 
     it 'refresh an access_token' do

--- a/spec/twitter_tweet_bot/api/tweet_spec.rb
+++ b/spec/twitter_tweet_bot/api/tweet_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TwitterTweetBot::API::Tweet do
 
     before do
       stub_post('https://api.twitter.com/2/tweets')
-        .to_return_json(body: response_body)
+        .and_return_json(body: response_body)
     end
 
     it 'posts a tweet' do

--- a/spec/twitter_tweet_bot/api/tweet_spec.rb
+++ b/spec/twitter_tweet_bot/api/tweet_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe TwitterTweetBot::API::Tweet do
         text: Faker::Lorem.word
       }
     end
-    let(:response_json) { { data: params.slice(:text) }.to_json }
+    let(:response_body) { { data: params.slice(:text) } }
 
     before do
       stub_post('https://api.twitter.com/2/tweets')
-        .to_return(body: response_json)
+        .to_return_json(body: response_body)
     end
 
     it 'posts a tweet' do
-      is_expected.to eq(response_json)
+      is_expected.to eq(response_body.to_json)
 
       expect(
         a_post('https://api.twitter.com/2/tweets')

--- a/spec/twitter_tweet_bot/api/users_me/params_spec.rb
+++ b/spec/twitter_tweet_bot/api/users_me/params_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe TwitterTweetBot::API::UsersMe.const_get(:Params) do # rubocop:disable RSpec/DescribeClass
+  describe '::build' do
+    context 'when param\'s values are string' do
+      let(:params) do
+        {
+          expansions: 'pinned_tweet_id',
+          tweet_fields: 'attachments',
+          user_fields: 'created_at'
+        }
+      end
+
+      it 'returns params for UsersMe API' do
+        described_class.build(params).then do |actual|
+          expect(actual['expansions']).to eq('pinned_tweet_id')
+          expect(actual['tweet.fields']).to eq('attachments')
+          expect(actual['user.fields']).to eq('created_at')
+        end
+      end
+
+      context 'when param\'s values are included an unknown key' do
+        before { params[:unknown] = '*' }
+
+        it 'trims an unknown key' do
+          expect(described_class.build(params)).not_to have_key(:unknown)
+        end
+      end
+    end
+
+    context 'when param\'s values are included Array' do
+      let(:params) do
+        {
+          expansions: 'pinned_tweet_id',
+          tweet_fields: %w[attachments],
+          user_fields: %w[created_at description]
+        }
+      end
+
+      it 'returns params for UsersMe API' do
+        described_class.build(params).then do |actual|
+          expect(actual['expansions']).to eq('pinned_tweet_id')
+          expect(actual['tweet.fields']).to eq('attachments')
+          expect(actual['user.fields']).to eq('created_at,description')
+        end
+      end
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/users_me_spec.rb
+++ b/spec/twitter_tweet_bot/api/users_me_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe TwitterTweetBot::API::UsersMe do
         params: {}
       }
     end
-    let(:response) { { data: { name: Faker::Internet.username } } }
+    let(:response_body) { { data: { name: Faker::Internet.username } } }
 
     before do
       stub_get('https://api.twitter.com/2/users/me')
-        .to_return_json(body: response)
+        .to_return_json(body: response_body)
     end
 
     it 'request current user\'s information' do
-      is_expected.to eq(response.to_json)
+      is_expected.to eq(response_body.to_json)
 
       expect(
         a_get('https://api.twitter.com/2/users/me')
@@ -49,7 +49,7 @@ RSpec.describe TwitterTweetBot::API::UsersMe do
           }
         )
       end
-      let(:response) do
+      let(:response_body) do
         {
           data: {
             name: Faker::Internet.username,
@@ -62,11 +62,11 @@ RSpec.describe TwitterTweetBot::API::UsersMe do
         reset_executed_requests!
 
         stub_get("https://api.twitter.com/2/users/me?#{query}")
-          .to_return_json(body: response)
+          .to_return_json(body: response_body)
       end
 
       it 'request current user\'s information with fields' do
-        is_expected.to eq(response.to_json)
+        is_expected.to eq(response_body.to_json)
 
         expect(
           a_get("https://api.twitter.com/2/users/me?#{query}")

--- a/spec/twitter_tweet_bot/api/users_me_spec.rb
+++ b/spec/twitter_tweet_bot/api/users_me_spec.rb
@@ -5,19 +5,18 @@ RSpec.describe TwitterTweetBot::API::UsersMe do
     let(:params) do
       {
         access_token: Faker::Alphanumeric.alpha(number: 5),
-        fields: {}
+        params: {}
       }
     end
-    let(:query) { URI.encode_www_form(params.slice(:fields)) }
-    let(:response_json) { { data: { name: Faker::Internet.username } }.to_json }
+    let(:response) { { data: { name: Faker::Internet.username } } }
 
     before do
       stub_get('https://api.twitter.com/2/users/me')
-        .to_return(body: response_json)
+        .to_return_json(body: response)
     end
 
-    it 'get current user\'s information' do
-      is_expected.to eq(response_json)
+    it 'request current user\'s information' do
+      is_expected.to eq(response.to_json)
 
       expect(
         a_get('https://api.twitter.com/2/users/me')
@@ -27,6 +26,57 @@ RSpec.describe TwitterTweetBot::API::UsersMe do
             }
           )
       ).to have_been_made.once
+    end
+
+    context 'when specified params' do
+      let(:params) do
+        {
+          access_token: Faker::Alphanumeric.alpha(number: 5),
+          params: {
+            expansions: 'pinned_tweet_id',
+            tweet_fields: 'attachments',
+            user_fields: %w[created_at description]
+          }
+        }
+      end
+
+      let(:query) do
+        URI.encode_www_form(
+          {
+            'expansions' => 'pinned_tweet_id',
+            'tweet.fields' => 'attachments',
+            'user.fields' => %w[created_at description].join(',')
+          }
+        )
+      end
+      let(:response) do
+        {
+          data: {
+            name: Faker::Internet.username,
+            created_at: Faker::Time.backward(days: 30).to_s
+          }
+        }
+      end
+
+      before do
+        reset_executed_requests!
+
+        stub_get("https://api.twitter.com/2/users/me?#{query}")
+          .to_return_json(body: response)
+      end
+
+      it 'request current user\'s information with fields' do
+        is_expected.to eq(response.to_json)
+
+        expect(
+          a_get("https://api.twitter.com/2/users/me?#{query}")
+            .with(
+              headers: {
+                'Authorization' => "Bearer #{params[:access_token]}"
+              }
+            )
+        ).to have_been_made.once
+      end
     end
   end
 end

--- a/spec/twitter_tweet_bot/api/users_me_spec.rb
+++ b/spec/twitter_tweet_bot/api/users_me_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TwitterTweetBot::API::UsersMe do
 
     before do
       stub_get('https://api.twitter.com/2/users/me')
-        .to_return_json(body: response_body)
+        .and_return_json(body: response_body)
     end
 
     it 'request current user\'s information' do
@@ -62,7 +62,7 @@ RSpec.describe TwitterTweetBot::API::UsersMe do
         reset_executed_requests!
 
         stub_get("https://api.twitter.com/2/users/me?#{query}")
-          .to_return_json(body: response_body)
+          .and_return_json(body: response_body)
       end
 
       it 'request current user\'s information with fields' do

--- a/spec/twitter_tweet_bot/entity/base_spec.rb
+++ b/spec/twitter_tweet_bot/entity/base_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe TwitterTweetBot::Entity::Base do
     end
   end
 
+  describe '#row' do
+    subject { entity_klass.new(data).row }
+
+    it 'returns a row data' do
+      is_expected.to be(data)
+    end
+  end
+
   describe '#foo' do
     subject { entity_klass.new(data).foo }
 


### PR DESCRIPTION
## Summary

Support following `API::UsersMe` params.

- `expansions`
- `tweet.fields`
- `user.fields`

```rb
# e.g.
TwitterTweetBot.users_me({ user_fields: %w[created_at] }).row[:data][:created_at]
=> "2023-01-01T00:00:00.000Z"
```

### And ...

Implement `TwitterTweetBot::Entity#row`.
(To provide accessing to all fields of Twitter's API response)

```rb
> TwitterTweetBot.users_me.username
=> "dev"

> TwitterTweetBot.users_me.row[:data][:username]
=> "dev"
```