### PR TITLE
Rename `TwitterTweetBot::Configration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ TwitterTweetBot.configure do |config|
   # Redirect URL After Authorization
   config.redirect_uri = 'https://example.com/twitter/callback'
   # Twitter's App Scopes with OAuth 2.0
-  config.scopes = ['tweet.read', 'tweet.write', 'users.read', 'offline.access']
+  config.scopes = %w[tweet.read tweet.write users.read offline.access]
 end
 ```
 

--- a/lib/twitter_tweet_bot.rb
+++ b/lib/twitter_tweet_bot.rb
@@ -1,18 +1,18 @@
 require 'twitter_tweet_bot/client'
-require 'twitter_tweet_bot/configration'
+require 'twitter_tweet_bot/configuration'
 require 'twitter_tweet_bot/version'
 
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/module/delegation'
 
 module TwitterTweetBot
-  NoConfigrationError = Class.new(StandardError).freeze
+  NoConfigurationError = Class.new(StandardError).freeze
 
   mattr_accessor :default_config
 
   class << self
     def configure(&block)
-      self.default_config = Configration.new(&block)
+      self.default_config = Configuration.new(&block)
     end
 
     def client(config = nil)
@@ -29,7 +29,7 @@ module TwitterTweetBot
     private
 
     def default_config!
-      default_config or raise NoConfigrationError
+      default_config or raise NoConfigurationError
     end
   end
 end

--- a/lib/twitter_tweet_bot/cache.rb
+++ b/lib/twitter_tweet_bot/cache.rb
@@ -6,7 +6,7 @@ require 'twitter_tweet_bot/cache/entity_ext'
 
 module TwitterTweetBot
   Client.prepend(Cache::ClientExt)
-  Configration.prepend(Cache::ConfigrationExt)
+  Configuration.prepend(Cache::ConfigurationExt)
 
   Entity::Authorization.include(Cache::EntityExt::Authorization)
   Entity::Token.include(Cache::EntityExt::Token)

--- a/lib/twitter_tweet_bot/cache/configuration_ext.rb
+++ b/lib/twitter_tweet_bot/cache/configuration_ext.rb
@@ -2,7 +2,7 @@ require 'twitter_tweet_bot/cache/store'
 
 module TwitterTweetBot
   module Cache
-    module ConfigrationExt
+    module ConfigurationExt
       attr_accessor :cache_provider
       attr_writer :cache
 

--- a/lib/twitter_tweet_bot/configuration.rb
+++ b/lib/twitter_tweet_bot/configuration.rb
@@ -1,5 +1,5 @@
 module TwitterTweetBot
-  class Configration
+  class Configuration
     attr_accessor :name,
                   :client_id,
                   :client_secret,


### PR DESCRIPTION
## Summary

Rename `TwitterTweetBot::Configration` to `TwitterTweetBot::Configuration`.
(Fixing a typo)

```rb
# Before
TwitterTweetBot::Configration

# After
TwitterTweetBot::Configuration
```