### PR TITLE
Rename `TwitterTweetBot::Entity#row` to `TwitterTweetBot::Entity#raw`

### DIFF
--- a/lib/twitter_tweet_bot/entity/base.rb
+++ b/lib/twitter_tweet_bot/entity/base.rb
@@ -13,16 +13,16 @@ module TwitterTweetBot
                           instance_writer: false,
                           default: fields
 
-          attr_reader :row
+          attr_reader :raw
 
           fields.each do |field|
             define_method(field) { target_fields[field] }
           end
 
           # @param [Hash] hash
-          define_method(:initialize) { |hash| @row = Hash(hash) }
+          define_method(:initialize) { |hash| @raw = Hash(hash) }
 
-          define_method(:target_fields) { row }
+          define_method(:target_fields) { raw }
           private :target_fields
         end
 

--- a/lib/twitter_tweet_bot/entity/tweet.rb
+++ b/lib/twitter_tweet_bot/entity/tweet.rb
@@ -14,7 +14,7 @@ module TwitterTweetBot
       private
 
       def target_fields
-        Hash(row[:data])
+        Hash(raw[:data])
       end
     end
   end

--- a/lib/twitter_tweet_bot/entity/user.rb
+++ b/lib/twitter_tweet_bot/entity/user.rb
@@ -14,7 +14,7 @@ module TwitterTweetBot
       private
 
       def target_fields
-        Hash(row[:data])
+        Hash(raw[:data])
       end
     end
   end

--- a/spec/support/twitter_tweet_bot/entity/base_examples.rb
+++ b/spec/support/twitter_tweet_bot/entity/base_examples.rb
@@ -38,8 +38,8 @@ module Spec
               end
             end
 
-            describe '#row' do
-              subject { described_class.new(body).row }
+            describe '#raw' do
+              subject { described_class.new(body).raw }
 
               it 'returns a body' do
                 is_expected.to be(body)

--- a/spec/twitter_tweet_bot/client/entity_spec.rb
+++ b/spec/twitter_tweet_bot/client/entity_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe TwitterTweetBot::Client::Entity do
 
     it 'wrap response as `Entity::Authorization`' do
       expect(authorization).to be_a(TwitterTweetBot::Entity::Authorization)
-      expect(authorization.row).to be(response_body)
+      expect(authorization.raw).to be(response_body)
       expect(authorization.url).to eq(response_body[:url])
       expect(authorization.code_verifier).to eq(response_body[:code_verifier])
       expect(authorization.state).to eq(response_body[:state])
@@ -54,7 +54,7 @@ RSpec.describe TwitterTweetBot::Client::Entity do
 
     it 'wrap response as `Entity::Token`' do
       expect(access_token).to be_a(TwitterTweetBot::Entity::Token)
-      expect(access_token.row).to eq(response_body)
+      expect(access_token.raw).to eq(response_body)
       expect(access_token.token_type).to eq(response_body[:token_type])
       expect(access_token.expires_in).to eq(response_body[:expires_in])
       expect(access_token.scope).to eq(response_body[:scope])
@@ -84,7 +84,7 @@ RSpec.describe TwitterTweetBot::Client::Entity do
 
     it 'wrap response as `Entity::Token`' do
       expect(refresh_token).to be_a(TwitterTweetBot::Entity::Token)
-      expect(refresh_token.row).to eq(response_body)
+      expect(refresh_token.raw).to eq(response_body)
       expect(refresh_token.token_type).to eq(response_body[:token_type])
       expect(refresh_token.expires_in).to eq(response_body[:expires_in])
       expect(refresh_token.scope).to eq(response_body[:scope])
@@ -114,7 +114,7 @@ RSpec.describe TwitterTweetBot::Client::Entity do
 
     it 'wrap response as `Entity::Tweet`' do
       expect(tweet).to be_a(TwitterTweetBot::Entity::Tweet)
-      expect(tweet.row).to eq(response_body)
+      expect(tweet.raw).to eq(response_body)
       expect(tweet.id).to eq(response_body[:data][:id])
       expect(tweet.edit_history_tweet_ids).to eq(response_body[:data][:edit_history_tweet_ids])
       expect(tweet.text).to eq(response_body[:data][:text])
@@ -142,7 +142,7 @@ RSpec.describe TwitterTweetBot::Client::Entity do
 
     it 'wrap response as `Entity::User`' do
       expect(users_me).to be_a(TwitterTweetBot::Entity::User)
-      expect(users_me.row).to eq(response_body)
+      expect(users_me.raw).to eq(response_body)
       expect(users_me.id).to eq(response_body[:data][:id])
       expect(users_me.name).to eq(response_body[:data][:name])
       expect(users_me.username).to eq(response_body[:data][:username])

--- a/spec/twitter_tweet_bot/client_spec.rb
+++ b/spec/twitter_tweet_bot/client_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe TwitterTweetBot::Client do
 
       it 'requests `API::Authorization`' do
         expect(authorization).to be_a(TwitterTweetBot::Entity::Authorization)
-        expect(authorization.row).to be(data)
+        expect(authorization.raw).to be(data)
         expect(authorization.url).to eq(data[:url])
         expect(authorization.code_verifier).to eq(data[:code_verifier])
         expect(authorization.state).to eq(data[:state])
@@ -61,7 +61,7 @@ RSpec.describe TwitterTweetBot::Client do
 
       it 'requests `API::Authorization`' do
         expect(authorization).to be_a(TwitterTweetBot::Entity::Authorization)
-        expect(authorization.row).to be(data)
+        expect(authorization.raw).to be(data)
         expect(authorization.url).to eq(data[:url])
         expect(authorization.code_verifier).to eq(data[:code_verifier])
         expect(authorization.state).to eq(data[:state])
@@ -112,7 +112,7 @@ RSpec.describe TwitterTweetBot::Client do
 
     it 'requests `API::AccessToken`' do
       expect(access_token).to be_a(TwitterTweetBot::Entity::Token)
-      expect(access_token.row).to eq(response_body)
+      expect(access_token.raw).to eq(response_body)
       expect(access_token.token_type).to eq(response_body[:token_type])
       expect(access_token.expires_in).to eq(response_body[:expires_in])
       expect(access_token.scope).to eq(response_body[:scope])
@@ -152,7 +152,7 @@ RSpec.describe TwitterTweetBot::Client do
 
     it 'requests `API::RefreshToken`' do
       expect(refresh_token).to be_a(TwitterTweetBot::Entity::Token)
-      expect(refresh_token.row).to eq(response_body)
+      expect(refresh_token.raw).to eq(response_body)
       expect(refresh_token.token_type).to eq(response_body[:token_type])
       expect(refresh_token.expires_in).to eq(response_body[:expires_in])
       expect(refresh_token.scope).to eq(response_body[:scope])
@@ -199,7 +199,7 @@ RSpec.describe TwitterTweetBot::Client do
 
     it 'requests `API::Tweet`' do
       expect(tweet).to be_a(TwitterTweetBot::Entity::Tweet)
-      expect(tweet.row).to eq(response_body)
+      expect(tweet.raw).to eq(response_body)
       expect(tweet.id).to eq(response_body[:data][:id])
       expect(tweet.edit_history_tweet_ids).to eq(response_body[:data][:edit_history_tweet_ids])
       expect(tweet.text).to eq(response_body[:data][:text])
@@ -239,7 +239,7 @@ RSpec.describe TwitterTweetBot::Client do
 
       it 'requests `API::UsersMe`' do
         expect(users_me).to be_a(TwitterTweetBot::Entity::User)
-        expect(users_me.row).to eq(response_body)
+        expect(users_me.raw).to eq(response_body)
         expect(users_me.id).to eq(response_body[:data][:id])
         expect(users_me.name).to eq(response_body[:data][:name])
         expect(users_me.username).to eq(response_body[:data][:username])
@@ -263,7 +263,7 @@ RSpec.describe TwitterTweetBot::Client do
 
       it 'requests `API::UsersMe`' do
         expect(users_me).to be_a(TwitterTweetBot::Entity::User)
-        expect(users_me.row).to eq(response_body)
+        expect(users_me.raw).to eq(response_body)
         expect(users_me.id).to eq(response_body[:data][:id])
         expect(users_me.name).to eq(response_body[:data][:name])
         expect(users_me.username).to eq(response_body[:data][:username])

--- a/spec/twitter_tweet_bot/entity/base_spec.rb
+++ b/spec/twitter_tweet_bot/entity/base_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe TwitterTweetBot::Entity::Base do
     end
   end
 
-  describe '#row' do
-    subject { entity_klass.new(data).row }
+  describe '#raw' do
+    subject { entity_klass.new(data).raw }
 
-    it 'returns a row data' do
+    it 'returns a raw data' do
       is_expected.to be(data)
     end
   end


### PR DESCRIPTION
## Summary

Rename `TwitterTweetBot::Entity#row` to `TwitterTweetBot::Entity#raw`.
Since the `row` meant `"**raw** API response"`.

```rb
# Before
> TwitterTweetBot.users_me.row[:data][:username]
=> "dev"

# After
> TwitterTweetBot.users_me.raw[:data][:username]
=> "dev"
```