### PR TITLE
Enhance support for Tweet Post API's params 🦾 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ TwitterTweetBot.post_tweet(token.access_token, 'Yeah!')
 #   @text="Yeah!">
 ```
 
+##### With [some params](https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets)
+
+```rb
+TwitterTweetBot.post_tweet(token.access_token, 'Yeah! Yeah!') do |params|
+  params.reply = { in_reply_to_tweet_id: '*******************' }
+end
+```
+
 #### Ex. Refresh an access token (required `'offline.access'` in scopes)
 
 ```rb

--- a/lib/twitter_tweet_bot/api/params/boolean_param.rb
+++ b/lib/twitter_tweet_bot/api/params/boolean_param.rb
@@ -1,0 +1,13 @@
+module TwitterTweetBot
+  module API
+    module Params
+      module BooleanParam
+        def self.build(key, value)
+          return {} unless value.is_a?(TrueClass) || value.is_a?(FalseClass)
+
+          { key => value }
+        end
+      end
+    end
+  end
+end

--- a/lib/twitter_tweet_bot/api/params/hash_param.rb
+++ b/lib/twitter_tweet_bot/api/params/hash_param.rb
@@ -1,0 +1,13 @@
+module TwitterTweetBot
+  module API
+    module Params
+      module HashParam
+        def self.build(key, value)
+          return {} unless value.is_a?(Hash)
+
+          { key => value }
+        end
+      end
+    end
+  end
+end

--- a/lib/twitter_tweet_bot/api/params/string_param.rb
+++ b/lib/twitter_tweet_bot/api/params/string_param.rb
@@ -3,7 +3,9 @@ module TwitterTweetBot
     module Params
       module StringParam
         def self.build(key, value)
-          { key => value.to_s }
+          return {} unless value.is_a?(String)
+
+          { key => value }
         end
       end
     end

--- a/lib/twitter_tweet_bot/api/params/string_param.rb
+++ b/lib/twitter_tweet_bot/api/params/string_param.rb
@@ -1,9 +1,9 @@
 module TwitterTweetBot
   module API
     module Params
-      module PlainParam
+      module StringParam
         def self.build(key, value)
-          { key => value }
+          { key => value.to_s }
         end
       end
     end

--- a/lib/twitter_tweet_bot/api/params/tweet_params.rb
+++ b/lib/twitter_tweet_bot/api/params/tweet_params.rb
@@ -1,0 +1,53 @@
+require 'twitter_tweet_bot/api/params/boolean_param'
+require 'twitter_tweet_bot/api/params/string_param'
+require 'twitter_tweet_bot/api/params/hash_param'
+
+module TwitterTweetBot
+  module API
+    module Params
+      class TweetParams
+        private_class_method :new
+
+        # @yield [params]
+        # @yieldparam params [TwitterTweetBot::API::Params::TweetParams]
+        def self.build(&block)
+          new(&block).build
+        end
+
+        # @see https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets
+        AVAILABLE_PARAMS = {
+          for_super_followers_only: BooleanParam,
+          text: StringParam,
+          direct_message_deep_link: StringParam,
+          quote_tweet_id: StringParam,
+          reply_settings: StringParam,
+          geo: HashParam,
+          media: HashParam,
+          poll: HashParam,
+          reply: HashParam
+        }.freeze
+
+        # @yield [params]
+        # @yieldparam params [TwitterTweetBot::API::Params::TweetParams]
+        def initialize(&block)
+          block&.call(self)
+        end
+
+        def params
+          @params ||= {}
+        end
+        alias build params
+
+        private :params
+
+        AVAILABLE_PARAMS.each do |name, param_klass|
+          define_method("#{name}=") do |value|
+            params.merge!(param_klass.build(name, value))
+          end
+        end
+
+        private_constant :AVAILABLE_PARAMS
+      end
+    end
+  end
+end

--- a/lib/twitter_tweet_bot/api/params/users_me_params.rb
+++ b/lib/twitter_tweet_bot/api/params/users_me_params.rb
@@ -1,5 +1,5 @@
 require 'twitter_tweet_bot/api/params/comma_separated_param'
-require 'twitter_tweet_bot/api/params/plain_param'
+require 'twitter_tweet_bot/api/params/string_param'
 
 module TwitterTweetBot
   module API
@@ -25,7 +25,7 @@ module TwitterTweetBot
         alias build params
 
         def expansions=(value)
-          params.merge!(PlainParam.build('expansions', value))
+          params.merge!(StringParam.build('expansions', value))
         end
 
         def tweet_fields=(value)

--- a/lib/twitter_tweet_bot/api/tweet.rb
+++ b/lib/twitter_tweet_bot/api/tweet.rb
@@ -1,4 +1,5 @@
 require 'twitter_tweet_bot/api/http'
+require 'twitter_tweet_bot/api/params/tweet_params'
 
 module TwitterTweetBot
   module API
@@ -9,19 +10,28 @@ module TwitterTweetBot
 
       API_ENDPOTNT = 'https://api.twitter.com/2/tweets'.freeze
 
-      def self.post(access_token:, text:, **)
-        new(access_token).post(text)
+      # @param [String] access_token
+      # @param [String] text
+      # @yield [params]
+      # @yieldparam params [TwitterTweetBot::API::Params::TweetParams]
+      def self.post(access_token:, text:, **, &block)
+        new(access_token).post(
+          Params::TweetParams.build do |params|
+            params.text = text
+            block&.call(params)
+          end
+        )
       end
 
       def initialize(access_token)
         @access_token = access_token
       end
 
-      def post(text)
+      def post(params)
         request(
           :post_json,
           API_ENDPOTNT,
-          { text: text },
+          params,
           bearer_authorization_header(access_token)
         )
       end

--- a/lib/twitter_tweet_bot/client/api.rb
+++ b/lib/twitter_tweet_bot/client/api.rb
@@ -28,9 +28,9 @@ module TwitterTweetBot
         )
       end
 
-      def post_tweet(access_token, text)
+      def post_tweet(access_token, text, &block)
         TwitterTweetBot::API::Tweet.post(
-          **params_with_config(access_token: access_token, text: text)
+          **params_with_config(access_token: access_token, text: text), &block
         )
       end
 

--- a/spec/twitter_tweet_bot/api/params/boolean_param_spec.rb
+++ b/spec/twitter_tweet_bot/api/params/boolean_param_spec.rb
@@ -1,5 +1,3 @@
-require 'twitter_tweet_bot/api/params/boolean_param'
-
 RSpec.describe TwitterTweetBot::API::Params::BooleanParam do
   describe '::build' do
     subject { described_class.build('foo', value) }

--- a/spec/twitter_tweet_bot/api/params/boolean_param_spec.rb
+++ b/spec/twitter_tweet_bot/api/params/boolean_param_spec.rb
@@ -1,0 +1,31 @@
+require 'twitter_tweet_bot/api/params/boolean_param'
+
+RSpec.describe TwitterTweetBot::API::Params::BooleanParam do
+  describe '::build' do
+    subject { described_class.build('foo', value) }
+
+    context 'when a value is true' do
+      let(:value) { true }
+
+      it 'returns params for an API request' do
+        is_expected.to eq({ 'foo' => value })
+      end
+    end
+
+    context 'when a value is false' do
+      let(:value) { false }
+
+      it 'returns params for an API request' do
+        is_expected.to eq({ 'foo' => value })
+      end
+    end
+
+    context 'when a value is NOT TrueClass/FalseClass' do
+      let(:value) { 'true' }
+
+      it 'returns params for an API request' do
+        is_expected.to eq({})
+      end
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/params/hash_param_spec.rb
+++ b/spec/twitter_tweet_bot/api/params/hash_param_spec.rb
@@ -1,5 +1,3 @@
-require 'twitter_tweet_bot/api/params/hash_param'
-
 RSpec.describe TwitterTweetBot::API::Params::HashParam do
   describe '::build' do
     subject { described_class.build('foo', value) }

--- a/spec/twitter_tweet_bot/api/params/hash_param_spec.rb
+++ b/spec/twitter_tweet_bot/api/params/hash_param_spec.rb
@@ -1,0 +1,23 @@
+require 'twitter_tweet_bot/api/params/hash_param'
+
+RSpec.describe TwitterTweetBot::API::Params::HashParam do
+  describe '::build' do
+    subject { described_class.build('foo', value) }
+
+    context 'when a value is Hash' do
+      let(:value) { { foge: 'huga' } }
+
+      it 'returns params for an API request' do
+        is_expected.to eq({ 'foo' => value })
+      end
+    end
+
+    context 'when a value is NOT Hash' do
+      let(:value) { 'bar' }
+
+      it 'returns params for an API request' do
+        is_expected.to eq({})
+      end
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/params/string_param_spec.rb
+++ b/spec/twitter_tweet_bot/api/params/string_param_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe TwitterTweetBot::API::Params::PlainParam do
+RSpec.describe TwitterTweetBot::API::Params::StringParam do
   describe '::build' do
     subject { described_class.build('foo', 'bar') }
 

--- a/spec/twitter_tweet_bot/api/params/string_param_spec.rb
+++ b/spec/twitter_tweet_bot/api/params/string_param_spec.rb
@@ -1,9 +1,23 @@
+require 'twitter_tweet_bot/api/params/string_param'
+
 RSpec.describe TwitterTweetBot::API::Params::StringParam do
   describe '::build' do
-    subject { described_class.build('foo', 'bar') }
+    subject { described_class.build('foo', value) }
 
-    it 'returns params for an API request' do
-      is_expected.to eq({ 'foo' => 'bar' })
+    context 'when a value is String' do
+      let(:value) { 'bar' }
+
+      it 'returns params for an API request' do
+        is_expected.to eq({ 'foo' => value })
+      end
+    end
+
+    context 'when a value is NOT String' do
+      let(:value) { Faker::Boolean.boolean }
+
+      it 'returns params for an API request' do
+        is_expected.to eq({})
+      end
     end
   end
 end

--- a/spec/twitter_tweet_bot/api/params/string_param_spec.rb
+++ b/spec/twitter_tweet_bot/api/params/string_param_spec.rb
@@ -1,5 +1,3 @@
-require 'twitter_tweet_bot/api/params/string_param'
-
 RSpec.describe TwitterTweetBot::API::Params::StringParam do
   describe '::build' do
     subject { described_class.build('foo', value) }

--- a/spec/twitter_tweet_bot/api/params/tweet_params_spec.rb
+++ b/spec/twitter_tweet_bot/api/params/tweet_params_spec.rb
@@ -1,0 +1,160 @@
+RSpec.describe TwitterTweetBot::API::Params::TweetParams do
+  describe '::build' do
+    context 'without block' do
+      subject { described_class.build }
+
+      it 'returns an empty hash' do
+        is_expected.to eq({})
+      end
+    end
+
+    context 'with block' do
+      describe 'for_super_followers_only' do
+        subject do
+          described_class.build do |params|
+            params.for_super_followers_only = for_super_followers_only
+          end
+        end
+
+        let(:for_super_followers_only) { Faker::Boolean.boolean }
+
+        it 'returns \'for_super_followers_only\' params for Tweet API' do
+          is_expected.to eq(
+            { for_super_followers_only: for_super_followers_only }
+          )
+        end
+      end
+
+      describe 'direct_message_deep_link' do
+        subject do
+          described_class.build do |params|
+            params.direct_message_deep_link = direct_message_deep_link
+          end
+        end
+
+        let(:direct_message_deep_link) { Faker::Internet.url }
+
+        it 'returns \'direct_message_deep_link\' params for Tweet API' do
+          is_expected.to eq(
+            { direct_message_deep_link: direct_message_deep_link }
+          )
+        end
+      end
+
+      describe 'text' do
+        subject do
+          described_class.build do |params|
+            params.text = text
+          end
+        end
+
+        let(:text) { Faker::Lorem.word }
+
+        it 'returns \'text\' params for Tweet API' do
+          is_expected.to eq({ text: text })
+        end
+      end
+
+      describe 'quote_tweet_id' do
+        subject do
+          described_class.build do |params|
+            params.quote_tweet_id = quote_tweet_id
+          end
+        end
+
+        let(:quote_tweet_id) { Faker::Internet.uuid }
+
+        it 'returns \'quote_tweet_id\' params for Tweet API' do
+          is_expected.to eq({ quote_tweet_id: quote_tweet_id })
+        end
+      end
+
+      describe 'reply_settings' do
+        subject do
+          described_class.build do |params|
+            params.reply_settings = reply_settings
+          end
+        end
+
+        let(:reply_settings) { %w[mentionedUsers following].sample }
+
+        it 'returns \'reply_settings\' params for Tweet API' do
+          is_expected.to eq({ reply_settings: reply_settings })
+        end
+      end
+
+      describe 'geo' do
+        subject do
+          described_class.build do |params|
+            params.geo = geo
+          end
+        end
+
+        let(:geo) do
+          { place_id: Faker::Internet.uuid }
+        end
+
+        it 'returns \'geo\' params for Tweet API' do
+          is_expected.to eq({ geo: geo })
+        end
+      end
+
+      describe 'media' do
+        subject do
+          described_class.build do |params|
+            params.media = media
+          end
+        end
+
+        let(:media) do
+          {
+            media_ids: [Faker::Internet.uuid],
+            tagged_user_ids: [Faker::Internet.uuid]
+          }
+        end
+
+        it 'returns \'media\' params for Tweet API' do
+          is_expected.to eq({ media: media })
+        end
+      end
+
+      describe 'poll' do
+        subject do
+          described_class.build do |params|
+            params.poll = poll
+          end
+        end
+
+        let(:poll) do
+          {
+            duration_minutes: 120,
+            options: %w[yes maybe no]
+          }
+        end
+
+        it 'returns \'poll\' params for Tweet API' do
+          is_expected.to eq({ poll: poll })
+        end
+      end
+
+      describe 'reply' do
+        subject do
+          described_class.build do |params|
+            params.reply = reply
+          end
+        end
+
+        let(:reply) do
+          {
+            in_reply_to_tweet_id: Faker::Internet.uuid,
+            exclude_reply_user_ids: [Faker::Internet.uuid]
+          }
+        end
+
+        it 'returns \'reply\' params for Tweet API' do
+          is_expected.to eq({ reply: reply })
+        end
+      end
+    end
+  end
+end

--- a/spec/twitter_tweet_bot/api/tweet_spec.rb
+++ b/spec/twitter_tweet_bot/api/tweet_spec.rb
@@ -1,33 +1,76 @@
 RSpec.describe TwitterTweetBot::API::Tweet do
   describe '::post' do
-    subject { described_class.post(**params) }
-
-    let(:params) do
-      {
-        access_token: Faker::Alphanumeric.alpha(number: 5),
-        text: Faker::Lorem.word
-      }
+    let(:access_token) { Faker::Alphanumeric.alpha(number: 5) }
+    let(:response_body) do
+      { data: { text: request_body[:text] } }
     end
-    let(:response_body) { { data: params.slice(:text) } }
 
     before do
       stub_post('https://api.twitter.com/2/tweets')
         .and_return_json(body: response_body)
     end
 
-    it 'posts a tweet' do
-      is_expected.to eq(response_body.to_json)
+    context 'without block' do
+      subject do
+        described_class.post(
+          access_token: access_token, text: request_body[:text]
+        )
+      end
 
-      expect(
-        a_post('https://api.twitter.com/2/tweets')
-          .with(
-            body: params.slice(:text).to_json,
-            headers: {
-              'Authorization' => "Bearer #{params[:access_token]}",
-              'Content-Type' => 'application/json'
-            }
-          )
-      ).to have_been_made.once
+      let(:request_body) do
+        { text: Faker::Lorem.word }
+      end
+
+      it 'posts a tweet' do
+        is_expected.to eq(response_body.to_json)
+
+        expect(
+          a_post('https://api.twitter.com/2/tweets')
+            .with(
+              body: request_body.to_json,
+              headers: {
+                'Authorization' => "Bearer #{access_token}",
+                'Content-Type' => 'application/json'
+              }
+            )
+        ).to have_been_made.once
+      end
+    end
+
+    context 'with block' do
+      subject do
+        described_class.post(
+          access_token: access_token, text: request_body[:text]
+        ) do |params|
+          params.quote_tweet_id = request_body[:quote_tweet_id]
+          params.geo = request_body[:geo]
+        end
+      end
+
+      let(:request_body) do
+        {
+          text: Faker::Lorem.word,
+          quote_tweet_id: Faker::Internet.uuid,
+          geo: {
+            place_id: Faker::Internet.uuid
+          }
+        }
+      end
+
+      it 'posts a tweet' do
+        is_expected.to eq(response_body.to_json)
+
+        expect(
+          a_post('https://api.twitter.com/2/tweets')
+            .with(
+              body: request_body.to_json,
+              headers: {
+                'Authorization' => "Bearer #{access_token}",
+                'Content-Type' => 'application/json'
+              }
+            )
+        ).to have_been_made.once
+      end
     end
   end
 end


### PR DESCRIPTION
Support following Tweet Post API's params.

- `for_super_followers_only`
- `direct_message_deep_link`
- `quote_tweet_id`
- `reply_settings`
- `geo`
- `media`
- `poll`
- `reply`

https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets

```rb
# e.g. reply a specific tweet
TwitterTweetBot.post_tweet('reply your tweet') do |params|
  params.reply = { in_reply_to_tweet_id: '*******************' }
end