### PR TITLE
Remove a definition of keyword arguments (`**`)

### DIFF
--- a/lib/twitter_tweet_bot/api/access_token.rb
+++ b/lib/twitter_tweet_bot/api/access_token.rb
@@ -16,8 +16,7 @@ module TwitterTweetBot
         client_secret:,
         redirect_uri:,
         code:,
-        code_verifier:,
-        **
+        code_verifier:
       )
         new(client_id, client_secret, redirect_uri)
           .fetch(code, code_verifier)

--- a/lib/twitter_tweet_bot/api/authorization.rb
+++ b/lib/twitter_tweet_bot/api/authorization.rb
@@ -17,8 +17,7 @@ module TwitterTweetBot
         scopes:,
         code_verifier:,
         code_challenge_method:,
-        state:,
-        **
+        state:
       )
         new(client_id, redirect_uri, scopes)
           .authorize(code_verifier, code_challenge_method, state)

--- a/lib/twitter_tweet_bot/api/refresh_token.rb
+++ b/lib/twitter_tweet_bot/api/refresh_token.rb
@@ -10,7 +10,7 @@ module TwitterTweetBot
       API_ENDPOTNT = 'https://api.twitter.com/2/oauth2/token'.freeze
       GRANT_TYPE = 'refresh_token'.freeze
 
-      def self.fetch(client_id:, client_secret:, refresh_token:, **)
+      def self.fetch(client_id:, client_secret:, refresh_token:)
         new(client_id, client_secret)
           .fetch(refresh_token)
       end

--- a/lib/twitter_tweet_bot/api/tweet.rb
+++ b/lib/twitter_tweet_bot/api/tweet.rb
@@ -14,7 +14,7 @@ module TwitterTweetBot
       # @param [String] text
       # @yield [params]
       # @yieldparam params [TwitterTweetBot::API::Params::TweetParams]
-      def self.post(access_token:, text:, **, &block)
+      def self.post(access_token:, text:, &block)
         new(access_token).post(
           Params::TweetParams.build do |params|
             params.text = text

--- a/lib/twitter_tweet_bot/api/users_me.rb
+++ b/lib/twitter_tweet_bot/api/users_me.rb
@@ -13,7 +13,7 @@ module TwitterTweetBot
       # @param [String] access_token
       # @yield [params]
       # @yieldparam params [TwitterTweetBot::API::Params::UsersMeParams]
-      def self.fetch(access_token:, **, &block)
+      def self.fetch(access_token:, &block)
         new(access_token).fetch(
           Params::UsersMeParams.build(&block)
         )

--- a/lib/twitter_tweet_bot/client/api.rb
+++ b/lib/twitter_tweet_bot/client/api.rb
@@ -5,45 +5,47 @@ module TwitterTweetBot
     module API
       def authorize(code_verifier = nil, code_challenge_method = nil, state = nil)
         TwitterTweetBot::API::Authorization.authorize(
-          **params_with_config(
-            code_verifier: code_verifier,
-            code_challenge_method: code_challenge_method,
-            state: state
-          )
+          **slice_config(:client_id, :redirect_uri, :scopes),
+          code_verifier: code_verifier,
+          code_challenge_method: code_challenge_method,
+          state: state
         )
       end
 
       def fetch_token(code, code_verifier)
         TwitterTweetBot::API::AccessToken.fetch(
-          **params_with_config(
-            code: code,
-            code_verifier: code_verifier
-          )
+          **slice_config(:client_id, :client_secret, :redirect_uri),
+          code: code,
+          code_verifier: code_verifier
         )
       end
 
       def refresh_token(refresh_token)
         TwitterTweetBot::API::RefreshToken.fetch(
-          **params_with_config(refresh_token: refresh_token)
+          **slice_config(:client_id, :client_secret),
+          refresh_token: refresh_token
         )
       end
 
       def post_tweet(access_token, text, &block)
         TwitterTweetBot::API::Tweet.post(
-          **params_with_config(access_token: access_token, text: text), &block
+          access_token: access_token,
+          text: text,
+          &block
         )
       end
 
       def users_me(access_token, &block)
         TwitterTweetBot::API::UsersMe.fetch(
-          **params_with_config(access_token: access_token), &block
+          access_token: access_token,
+          &block
         )
       end
 
       private
 
-      def params_with_config(**params)
-        config.to_hash.merge(**params)
+      def slice_config(*keys)
+        config.to_hash.slice(*keys)
       end
     end
   end

--- a/spec/twitter_tweet_bot/client/api_spec.rb
+++ b/spec/twitter_tweet_bot/client/api_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe TwitterTweetBot::Client::API do
         expect(TwitterTweetBot::API::Authorization).to(
           have_received(:authorize)
             .with(
-              **config,
+              **config.slice(:client_id, :redirect_uri, :scopes),
               code_verifier: nil,
               code_challenge_method: nil,
               state: nil
@@ -72,7 +72,7 @@ RSpec.describe TwitterTweetBot::Client::API do
         expect(TwitterTweetBot::API::Authorization).to(
           have_received(:authorize)
             .with(
-              **config,
+              **config.slice(:client_id, :redirect_uri, :scopes),
               code_verifier: data[:code_verifier],
               code_challenge_method: 'S256',
               state: data[:state]
@@ -118,7 +118,10 @@ RSpec.describe TwitterTweetBot::Client::API do
 
       expect(TwitterTweetBot::API::AccessToken).to(
         have_received(:fetch)
-          .with(**config, **params)
+          .with(
+            **config.slice(:client_id, :client_secret, :redirect_uri),
+            **params
+          )
           .once
       )
     end
@@ -154,7 +157,10 @@ RSpec.describe TwitterTweetBot::Client::API do
 
       expect(TwitterTweetBot::API::RefreshToken).to(
         have_received(:fetch)
-          .with(**config, refresh_token: refresh_token)
+          .with(
+            **config.slice(:client_id, :client_secret),
+            refresh_token: refresh_token
+          )
           .once
       )
     end
@@ -196,7 +202,6 @@ RSpec.describe TwitterTweetBot::Client::API do
         expect(TwitterTweetBot::API::Tweet).to(
           have_received(:post)
             .with(
-              **config,
               access_token: access_token,
               text: request_body[:text]
             )
@@ -231,7 +236,7 @@ RSpec.describe TwitterTweetBot::Client::API do
             expect(
               Struct.new(:for_super_followers_only, :media).new.tap(&block).to_h
             ).to eq(request_body)
-          end.with(**config, access_token: access_token, text: nil).once
+          end.with(access_token: access_token, text: nil).once
         )
       end
     end
@@ -267,7 +272,7 @@ RSpec.describe TwitterTweetBot::Client::API do
 
         expect(TwitterTweetBot::API::UsersMe).to(
           have_received(:fetch)
-            .with(**config, access_token: access_token)
+            .with(access_token: access_token)
             .once
         )
       end
@@ -290,7 +295,7 @@ RSpec.describe TwitterTweetBot::Client::API do
             expect(
               Struct.new(:user_fields).new.tap(&block).to_h
             ).to eq({ user_fields: 'created_at' })
-          end.with(**config, access_token: access_token).once
+          end.with(access_token: access_token).once
         )
       end
     end

--- a/spec/twitter_tweet_bot/client_spec.rb
+++ b/spec/twitter_tweet_bot/client_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe TwitterTweetBot::Client do
         expect(TwitterTweetBot::API::Authorization).to(
           have_received(:authorize)
             .with(
-              **config,
+              **config.slice(:client_id, :redirect_uri, :scopes),
               code_verifier: nil,
               code_challenge_method: nil,
               state: nil
@@ -69,7 +69,7 @@ RSpec.describe TwitterTweetBot::Client do
         expect(TwitterTweetBot::API::Authorization).to(
           have_received(:authorize)
             .with(
-              **config,
+              **config.slice(:client_id, :redirect_uri, :scopes),
               code_verifier: data[:code_verifier],
               code_challenge_method: 'S256',
               state: data[:state]
@@ -121,7 +121,10 @@ RSpec.describe TwitterTweetBot::Client do
 
       expect(TwitterTweetBot::API::AccessToken).to(
         have_received(:fetch)
-          .with(**config, **params)
+          .with(
+            **config.slice(:client_id, :client_secret, :redirect_uri),
+            **params
+          )
           .once
       )
     end
@@ -161,7 +164,10 @@ RSpec.describe TwitterTweetBot::Client do
 
       expect(TwitterTweetBot::API::RefreshToken).to(
         have_received(:fetch)
-          .with(**config, refresh_token: token)
+          .with(
+            **config.slice(:client_id, :client_secret),
+            refresh_token: token
+          )
           .once
       )
     end
@@ -206,7 +212,7 @@ RSpec.describe TwitterTweetBot::Client do
 
         expect(TwitterTweetBot::API::Tweet).to(
           have_received(:post)
-            .with(**config, access_token: access_token, text: request_body[:text])
+            .with(access_token: access_token, text: request_body[:text])
             .once
         )
       end
@@ -245,7 +251,7 @@ RSpec.describe TwitterTweetBot::Client do
             expect(
               Struct.new(:reply_settings, :reply).new.tap(&block).to_h
             ).to eq(request_body.except(:text))
-          end.with(**config, access_token: access_token, text: request_body[:text]).once
+          end.with(access_token: access_token, text: request_body[:text]).once
         )
       end
     end
@@ -285,7 +291,7 @@ RSpec.describe TwitterTweetBot::Client do
 
         expect(TwitterTweetBot::API::UsersMe).to(
           have_received(:fetch)
-            .with(**config, access_token: access_token)
+            .with(access_token: access_token)
             .once
         )
       end
@@ -312,7 +318,7 @@ RSpec.describe TwitterTweetBot::Client do
             expect(
               Struct.new(:tweet_fields).new.tap(&block).to_h
             ).to eq({ tweet_fields: 'attachments' })
-          end.with(**config, access_token: access_token).once
+          end.with(access_token: access_token).once
         )
       end
     end


### PR DESCRIPTION
## Summary
Remove a definition of keyword arguments (`**`).
Specify arguments explicitly from a caller of methods.