### PR TITLE
Remove unused `ls`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -118,7 +118,6 @@ jobs:
       - name: Build reports
         id: reports
         run: |
-          ls .
           ls -F . | grep -v / | xargs -I ARG sh -c '../template.sh "ARG" >> ../result.txt'
         working-directory: ${{ github.workspace }}/outputs
 


### PR DESCRIPTION
## Summary

Remove `ls` in ruby.yml.
Since `ls` was for debugging only.